### PR TITLE
fix(GitHooksExtension): Add documentation about overwriting hook files

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,3 +180,17 @@ gitHooks {
     createHooks()
 }
 ```
+
+If you want to be able to always overwrite your hook changes pass `true` to the createHooks() method
+```kotlin
+gitHooks {
+    preCommit {
+        from { // Creates a fresh script with a bash shebang line
+            """
+            echo some bash code you have changed
+            """
+        }
+    }
+    createHooks(true)
+}
+```

--- a/src/main/kotlin/org/danilopianini/gradle/git/hooks/GitHooksExtension.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/git/hooks/GitHooksExtension.kt
@@ -70,6 +70,9 @@ open class GitHooksExtension(val settings: Settings) : Serializable {
                         |
                         |New content:
                         ${script.withMargins()}
+                        |
+                        |If you want to overwrite this file on every change add true to the createHooks(true) 
+                        |method in your settings.gradle.kts
                         """.trimMargin().lines().joinToString(separator = "\n") { "WARNING: $it" }
                     )
                     if (overwriteExisting) {


### PR DESCRIPTION
## Changes

I have added some documentation about how to set the true flag on the overwrite of the hooks.

## Context

I made these changes because I had to read the code to figure out how to do this and thought it would be good to do that.

## Documentation (please check one with an [x])

- [x] I have updated the README.md file, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] No unit tests but ran on a real Gradle project, or
- [ ] Newly added/modified unit tests

