### PR TITLE
feat: add api for configuring commit-hooks based on files

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ either requiring their success or not, through `tasks`
 gitHooks {
     path = "some/folder" // custom git repository location, defaults to the local project and scans the parents 
     preCommit {
-        // Script downloaded from a source, can be a String or URL
+        // Script from a source, can be a String, URL or File 
         from("https://my.repo/pre-commit.sh")
         // Content can be added at the bottom of the script
         appendScript {

--- a/src/main/kotlin/org/danilopianini/gradle/git/hooks/ScriptContext.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/git/hooks/ScriptContext.kt
@@ -2,6 +2,7 @@ package org.danilopianini.gradle.git.hooks
 
 import org.gradle.api.Task
 import org.gradle.api.tasks.TaskProvider
+import java.io.File
 import java.net.URL
 
 /**
@@ -23,6 +24,11 @@ interface ScriptContext {
      * Appends the result of the provided function to the existing script.
      */
     fun appendScript(script: () -> String)
+
+    /**
+     * Generates a script from the provided [file].
+     */
+    fun from(file: File) = from("") { file.readText() }
 
     /**
      * Generates a script from the provided [url].


### PR DESCRIPTION
## Changes

Minor improvement. I've added api for configuring commit hooks based on `File` in addition to `String` and `URL`.

## Context

I find it useful to store commit hooks inside files in my project. For now this case looks a bit ugly in build scripts.

## Documentation (please check one with an [x])

- [x] I have updated the README.md file, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] No unit tests but ran on a real Gradle project, or
- [ ] Newly added/modified unit tests

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will likely be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
