### PR TITLE
feat: allow to instantiate extension w/o settings

### DIFF
--- a/src/main/kotlin/org/danilopianini/gradle/git/hooks/GitHooksExtension.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/git/hooks/GitHooksExtension.kt
@@ -9,10 +9,12 @@ import java.io.Serializable
  * DSL entry point, to be applied to [settings].gradle.kts.
  */
 open class GitHooksExtension(
-    val settings: Settings,
+    val repoRoot: File,
 ) : Serializable {
     private var hooks: Map<String, String> = emptyMap()
     private var pathHasBeenManuallySet = false
+
+    constructor(settings: Settings) : this(settings.rootDir)
 
     /**
      * The git repository root. If unset, it will be searched recursively from the project root towards the

--- a/src/main/kotlin/org/danilopianini/gradle/git/hooks/GradleGitHooksPlugin.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/git/hooks/GradleGitHooksPlugin.kt
@@ -21,6 +21,6 @@ open class GradleGitHooksPlugin : Plugin<Any> {
             }
             """.trimIndent()
         }
-        settings.extensions.create<GitHooksExtension>(GitHooksExtension.NAME, settings)
+        settings.extensions.create<GitHooksExtension>(GitHooksExtension.NAME, settings.settingsDir)
     }
 }


### PR DESCRIPTION
allowing to pass the path to the extension enable usage even after the settings have been evaluated

## Changes

I added another constructor to allow using the `GitHooksExtension` without `Settings` object. 

## Context

My problem is that I cannot use your plugin withing the `settings.gradle.kts`. My setup is complex and I basically can only have plugins in my `build.gradle.kts`. With this change I am able to figure out the path myself and create my instance of the `GitHooksExtension` myself and pass the path.

That means: When it is not absolutely required that the plugin is applied to the `settings.gradle.kts` this would even be preferable.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the README.md file, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] No unit tests but ran on a real Gradle project, or
- [ ] Newly added/modified unit tests

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will likely be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
